### PR TITLE
Clean viewers count string containing dots or commas

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -264,7 +264,7 @@ async function watchStreamUntilDropCompleted(page, streamUrl, twitchCredentials,
     progressBar.on('redraw-post', () => {
         isFirstOutput = false;
     });
-    progressBar.start(requiredMinutesWatched, 0, {'viewers': await streamPage.getViewerCount(), 'uptime': await streamPage.getUptime()});
+    progressBar.start(requiredMinutesWatched, 0, {'viewers': await streamPage.getViewersCount(), 'uptime': await streamPage.getUptime()});
 
     let wasInventoryDropNull = false;
     let lastMinutesWatched = -1;
@@ -301,7 +301,7 @@ async function watchStreamUntilDropCompleted(page, streamUrl, twitchCredentials,
             lastProgressCheckTime = new Date().getTime();
         }
 
-        progressBar.update(currentMinutesWatched, {'viewers': await streamPage.getViewerCount(), 'uptime': await streamPage.getUptime()});
+        progressBar.update(currentMinutesWatched, {'viewers': await streamPage.getViewersCount(), 'uptime': await streamPage.getUptime()});
 
         // Claim community points
         try{

--- a/src/pages/stream.js
+++ b/src/pages/stream.js
@@ -32,11 +32,12 @@ class StreamPage {
         }
     }
 
-    async getViewerCount(){
+    async getViewersCount(){
         const element = await this._page.$('p[data-a-target="animated-channel-viewers-count"]');
         const property = await element.getProperty('innerText');
         const value = await property.jsonValue();
-        return parseInt(value);
+        const cleanValue = value.replace(/[.,]/g, '');
+        return parseInt(cleanValue);
     }
 
     async getUptime(){


### PR DESCRIPTION
Viewers count above 999 adds a dot or comma, parseInt parses that as a float, so it's necessary to clean it beforehand