### PR TITLE
Add arg to update games list

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,4 @@ Below is a list of all available options.
 | <code>&#8209;&#8209;headless&nbsp;\<boolean\></code> | `headless` | Toggle headless mode. If false, this will display the browser at all times. Useful for debugging. | `true` |
 | <code>&#8209;&#8209;interval&nbsp;\<minutes\></code> | `interval` | The number of minutes to wait between checking for new drop campaigns.| `15` |
 | <code>&#8209;&#8209;browser&#8209;args&nbsp;\<args\></code> | `browser_args` | Extra arguments to pass to the browser instance. | `[]` |
+| <code>&#8209;&#8209;update&#8209;games</code> | | Updates `games.csv` with current campaigns games and exits after it's done | |

--- a/games.csv
+++ b/games.csv
@@ -28,7 +28,6 @@ Gwent: The Witcher Card Game,493217
 Hearthstone,138585
 Hood: Outlaws & Legends,519108
 HUMANKIND,514071
-ID,Name
 Infestation: Battle Royale,516316
 Infestation: Survivor Stories,66432
 Infestation: The New Z,491289
@@ -40,7 +39,6 @@ Madden NFL 22,966064811
 Marbles On Stream,509511
 Mortal Shell,516915
 Myth of Empires,805842275
-Name,ID
 Naraka: Bladepoint,515474
 New World,493597
 Out of the Park Baseball 22,1886157643
@@ -52,6 +50,7 @@ Phantom Abyss,1812167143
 Project Genesis,512898
 PUBG: BATTLEGROUNDS,493057
 Rex.io,518699
+Riders Republic,519559
 Rocket League,30921
 Rogue Company,514194
 Rust,263490
@@ -60,6 +59,7 @@ Sea of Thieves,490377
 Sector's Edge,513252
 Skydome,510074
 SMITE,32507
+Special Events,509663
 Stream Raiders,511230
 The Crew 2,497118
 The Elder Scrolls Online,65654

--- a/games.csv
+++ b/games.csv
@@ -1,73 +1,74 @@
-510218,Among Us
-498638,Anno 1800
-511224,Apex Legends
-511746,Back 4 Blood
-386821,Black Desert Online
-1820173024,Blankos Block Party
-498523,Conqueror's Blade
-27101,Crossfire
-492113,Crossout
-489956,Crowfall
-1788326126,Diablo II: Resurrected
-488634,Don't Starve Together
-513558,DwarfHeim
-500907,ELYON
-505257,Enlisted
-491931,Escape from Tarkov
-512864,Eternal Return
-518204,FIFA 21
-504798,FIFA Online 4
-516513,FUSER
-515486,First Class Trouble
-490382,For Honor
-33214,Fortnite
-1041038203,GangV: Battle Royale
-14333696,Goose Goose Duck
-493217,Gwent: The Witcher Card Game
-514071,HUMANKIND
-138585,Hearthstone
-519108,Hood: Outlaws & Legends
-516316,Infestation: Battle Royale
-66432,Infestation: Survivor Stories
-491289,Infestation: The New Z
-483809063,Iron Conflict
-1924769596,Knockout City
-508391,Krunker
-512182,Lemnis Gate
-966064811,Madden NFL 22
-509511,Marbles On Stream
-516915,Mortal Shell
-805842275,Myth of Empires
-515474,Naraka: Bladepoint
-493597,New World
-1886157643,Out of the Park Baseball 22
-518847,Overcooked! All You Can Eat
-488552,Overwatch
-493057,PUBG: BATTLEGROUNDS
-491115,Paladins
-29307,Path of Exile
-1812167143,Phantom Abyss
-512898,Project Genesis
-518699,Rex.io
-519559,Riders Republic
-30921,Rocket League
-514194,Rogue Company
-263490,Rust
-32507,SMITE
-517476,Sabotaj
-490377,Sea of Thieves
-513252,Sector's Edge
-510074,Skydome
-509663,Special Events
-511230,Stream Raiders
-497118,The Crew 2
-65654,The Elder Scrolls Online
-460630,Tom Clancy's Rainbow Six Siege
-412756,Trove
-461427,WWE SuperCard
-66366,War Thunder
-66170,Warframe
-27546,World of Tanks
-32502,World of Warships
-494531,XERA: Survival
-1618840991,Zenith: The Last City
+Name,ID
+Among Us,510218
+Anno 1800,498638
+Apex Legends,511224
+Back 4 Blood,511746
+Black Desert Online,386821
+Blankos Block Party,1820173024
+Conqueror's Blade,498523
+Crossfire,27101
+Crossout,492113
+Crowfall,489956
+Diablo II: Resurrected,1788326126
+Don't Starve Together,488634
+DwarfHeim,513558
+ELYON,500907
+Enlisted,505257
+Escape from Tarkov,491931
+Eternal Return,512864
+FIFA 21,518204
+FIFA Online 4,504798
+First Class Trouble,515486
+For Honor,490382
+Fortnite,33214
+FUSER,516513
+GangV: Battle Royale,1041038203
+Goose Goose Duck,14333696
+Gwent: The Witcher Card Game,493217
+Hearthstone,138585
+Hood: Outlaws & Legends,519108
+HUMANKIND,514071
+ID,Name
+Infestation: Battle Royale,516316
+Infestation: Survivor Stories,66432
+Infestation: The New Z,491289
+Iron Conflict,483809063
+Knockout City,1924769596
+Krunker,508391
+Lemnis Gate,512182
+Madden NFL 22,966064811
+Marbles On Stream,509511
+Mortal Shell,516915
+Myth of Empires,805842275
+Name,ID
+Naraka: Bladepoint,515474
+New World,493597
+Out of the Park Baseball 22,1886157643
+Overcooked! All You Can Eat,518847
+Overwatch,488552
+Paladins,491115
+Path of Exile,29307
+Phantom Abyss,1812167143
+Project Genesis,512898
+PUBG: BATTLEGROUNDS,493057
+Rex.io,518699
+Rocket League,30921
+Rogue Company,514194
+Rust,263490
+Sabotaj,517476
+Sea of Thieves,490377
+Sector's Edge,513252
+Skydome,510074
+SMITE,32507
+Stream Raiders,511230
+The Crew 2,497118
+The Elder Scrolls Online,65654
+Tom Clancy's Rainbow Six Siege,460630
+Trove,412756
+War Thunder,66366
+Warframe,66170
+World of Tanks,27546
+World of Warships,32502
+WWE SuperCard,461427
+XERA: Survival,494531
+Zenith: The Last City,1618840991

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "A bot for automatically collecting Twitch drops.",
   "main": "src/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node src/index.js",
+    "updateGames": "node src/index.js --update-games"
   },
   "keywords": [],
   "author": "",

--- a/src/index.js
+++ b/src/index.js
@@ -495,29 +495,30 @@ function areCookiesValid(cookies, username) {
 }
 
 function updateGames(campaigns){
-    logger.info('Parsing games...')
+    logger.info('Parsing games...');
     const gamesPath = './games.csv'
     const oldGames = fs
         .readFileSync(gamesPath, {encoding: 'utf-8'})
         .split('\r\n')
+        .slice(1)  // Ignore header row
         .filter(game => !!game)
-        .map(game => game.split(','))
+        .map(game => game.split(','));
     const newGames = [
         ...oldGames,
         ...campaigns.map(campaign => [campaign['game']['displayName'],campaign['game']['id']])
-    ]
+    ];
     const games = newGames
         .filter((game, index) => newGames.findIndex(g => g[1] === game[1]) >= index)
-        .sort((a, b) => a[0].localeCompare(b[0]))
+        .sort((a, b) => a[0].localeCompare(b[0]));
     // TODO: ask interactively if users wants to add some to the config file?
     const toWrite = games
         .map(game => game.join(','))
-        .join('\r\n')
+        .join('\r\n');
     fs.writeFileSync(
-        'games.csv',
-        'Name,ID\r\n'.concat(toWrite).concat('\r\n'),
+        gamesPath,
+        'Name,ID\r\n' + toWrite + '\r\n',
         {encoding: 'utf-8'});
-    logger.info('Games list updated')
+    logger.info('Games list updated');
 }
 
 // Options defined here can be configured in either the config file or as command-line arguments
@@ -591,8 +592,8 @@ const options = [
         default: false,
         argparse: {
             action: 'store_true',
-        },
-    },
+        }
+    }
 ]
 
 // Parse arguments


### PR DESCRIPTION
I added the arg `--update-games` to join local games list with current campaigns and reversed name and id order in the .csv file, imho it makes more sense if you are going through it visually. Comment if you want that bit to be reversed
I also added `npm run start` and `npm run updateGames` as shortcuts, I'll add more shortcuts later