### PR TITLE
Websocket message fixes

### DIFF
--- a/src/web_socket_listener.ts
+++ b/src/web_socket_listener.ts
@@ -58,6 +58,7 @@ class WebSocketListener extends EventEmitter {
 
                 case 'points-earned':
                 case 'reward-redeemed':
+                case 'claim-claimed':
                     return true;
             }
             return false;
@@ -78,7 +79,8 @@ class WebSocketListener extends EventEmitter {
         'polls': this.#ignoreTopicHandler,
         'channel-ad-poll-update-events': this.#ignoreTopicHandler,
         'channel-bounty-board-events.cta': this.#ignoreTopicHandler,
-        'crowd-chant-channel-v1': this.#ignoreTopicHandler
+        'crowd-chant-channel-v1': this.#ignoreTopicHandler,
+        'stream-change-v1': this.#ignoreTopicHandler,
     };
 
     async attach(page: Page) {


### PR DESCRIPTION
1. Fixes an issue with the message type for `community-points-user-v1` giving back `claim-claimed`.
2. Fixes an issue with a non existing topic handler for `stream-change-v1`.