### PR TITLE
add browser_userdata to config, to set puppeteer's userDataDir

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ Below is a list of all available options.
 
 `‑‑browser‑args <args>` | `browser_args` Extra arguments to pass to the browser instance. If provided as a command line argument, this should be a comma-separated list of args. Note that `\ ` is used as an escape character so if you want to use a comma in one of the args, it needs to be escaped so this `--some-arg=a,b,c` would be `--some-arg=a\,b\,c` If provided in the JSON config, this should be an array of strings.
 
+`‑‑browser‑userdata <path>` | `browser_args` If set, use a custom folder as your Chrome profile `--user-data-dir`. By default, Puppeteer will create a fresh folder with a randomized name on each start.
+
 `‑‑watch‑unlisted‑games` | `watch_unlisted_games` When `true`, the app will watch streams of games that are not listed in the config if the listed games' campaigns are completed or no streams are active.
 
 - Default: `false`

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Below is a list of all available options.
 
 `‑‑browser‑args <args>` | `browser_args` Extra arguments to pass to the browser instance. If provided as a command line argument, this should be a comma-separated list of args. Note that `\ ` is used as an escape character so if you want to use a comma in one of the args, it needs to be escaped so this `--some-arg=a,b,c` would be `--some-arg=a\,b\,c` If provided in the JSON config, this should be an array of strings.
 
-`‑‑browser‑userdata <path>` | `browser_args` If set, use a custom folder as your Chrome profile `--user-data-dir`. By default, Puppeteer will create a fresh folder with a randomized name on each start.
+`‑‑browser‑userdata <path>` | `browser_args` If set, use a custom folder as your Chrome profile `--user-data-dir`. By default, Puppeteer will create a fresh folder with a randomized name on each start. If you set this option, and you idle for drops on multiple Twitch accounts by running multiple instaces of Twitch Drops Bot, be careful not to set the same folder for multiple accounts.
 
 `‑‑watch‑unlisted‑games` | `watch_unlisted_games` When `true`, the app will watch streams of games that are not listed in the config if the listed games' campaigns are completed or no streams are active.
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -294,6 +294,7 @@ const options = [
     new IntegerOption("--failed-stream-retry", {defaultValue: 3}),
     new IntegerOption("--failed-stream-timeout", {defaultValue: 30}),
     new StringListOption("--browser-args"),
+    new StringOption("--browser-userdata"),
     /*    new BooleanOption('--update-games', null, false), TODO: auto update games.csv ? */
     new BooleanOption("--watch-unlisted-games"),
     new BooleanOption("--hide-video"),
@@ -356,6 +357,7 @@ export interface Config {
     failed_stream_retry: number,
     failed_stream_timeout: number,
     browser_args: string[],
+    browser_userdata: string,
     watch_unlisted_games: boolean,
     hide_video: boolean,
     cookies_path: string,
@@ -532,7 +534,8 @@ async function main(): Promise<void> {
     const browser = await puppeteer.launch({
         headless: config["headless"],
         executablePath: config["browser"],
-        args: config["browser_args"]
+        args: config["browser_args"],
+        ...(config["browser_userdata"] && { userDataDir: config["browser_userdata"]})
     });
 
     // Automatically stop this program if the browser is closed
@@ -630,7 +633,8 @@ async function main(): Promise<void> {
             loginBrowser = await puppeteer.launch({
                 headless: false,
                 executablePath: config["browser"],
-                args: config["browser_args"]
+                args: config["browser_args"],
+                ...(config["browser_userdata"] && { userDataDir: config["browser_userdata"]})
             });
         }
 


### PR DESCRIPTION
Otherwise, two --user-data-dir are sent to Chrome, which has unexpected effects.

On reflection, adding this to update_games wouldn't be smart, since the updater should be able to run just fine while you're idling streams. You can't have two Chrome sesssions with the same user data directory, and thus you can't have two puppeteers accessing the same Chrome profile.