### PR TITLE
Fix TS2503 and TS6133 errors..

### DIFF
--- a/src/pages/login.ts
+++ b/src/pages/login.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import prompt from "prompt";
 prompt.start();  // Initialize prompt (this should only be called once!)
 
-import puppeteer, {TimeoutError} from "puppeteer";
+import {TimeoutError, ElementHandle} from "puppeteer";
 
 import {TwitchPage} from "./page.js";
 import logger from "../logger.js";
@@ -113,7 +113,7 @@ export class LoginPage extends TwitchPage {
                                 continue;
                             }
                             logger.info("Resent verification email");
-                            await ((resendCodeButton) as puppeteer.ElementHandle<Element>).click();
+                            await ((resendCodeButton) as ElementHandle<Element>).click();
                         } else {
                             break;
                         }
@@ -125,7 +125,7 @@ export class LoginPage extends TwitchPage {
                         logger.error("first_input was null!");
                         break
                     }
-                    await ((first_input) as puppeteer.ElementHandle<Element>).click();
+                    await ((first_input) as ElementHandle<Element>).click();
                     await this.page.keyboard.type(code);
                     break;
                 } catch (error) {
@@ -152,7 +152,7 @@ export class LoginPage extends TwitchPage {
                         logger.error("first_input was null!");
                         break
                     }
-                    await ((first_input) as puppeteer.ElementHandle<Element>).click();
+                    await ((first_input) as ElementHandle<Element>).click();
                     await this.page.keyboard.type(code);
 
                     // Click submit
@@ -161,7 +161,7 @@ export class LoginPage extends TwitchPage {
                         logger.error("button was null!");
                         break
                     }
-                    await ((button) as puppeteer.ElementHandle<Element>).click();
+                    await ((button) as ElementHandle<Element>).click();
 
                     break;
                 } catch (error) {

--- a/src/twitch_drops_bot.ts
+++ b/src/twitch_drops_bot.ts
@@ -5,7 +5,7 @@ import _ from "lodash";
 import SortedArray from "sorted-array-type";
 // @ts-ignore
 import WaitNotify from "wait-notify";
-import puppeteer, {Browser, TimeoutError, ElementHandle, Page} from "puppeteer";
+import {Browser, TimeoutError, ElementHandle, Page} from "puppeteer";
 
 import Component from "./components/component.js";
 import DropProgressComponent from "./components/drop_progress.js";
@@ -1319,7 +1319,7 @@ export class TwitchDropsBot extends EventEmitter {
 
             // Wait for the page to load completely (hopefully). This checks the video player container for any DOM changes and waits until there haven't been any changes for a few seconds.
             logger.info("Waiting for page to load...");
-            const element = (await this.#page.waitForXPath("//div[@data-a-player-state]")) as puppeteer.ElementHandle<Element>;
+            const element = (await this.#page.waitForXPath("//div[@data-a-player-state]")) as ElementHandle<Element>;
             await this.#waitUntilElementRendered(this.#page, element);
 
             const streamPage = new StreamPage(this.#page);


### PR DESCRIPTION
When running `npm run build` during the compile step I got the following errors:

```
> twitch_drops_bot@1.3.3 compile
> tsc --pretty

src/pages/login.ts:6:8 - error TS6133: 'puppeteer' is declared but its value is never read.
   6 import puppeteer, {TimeoutError} from "puppeteer";
            ~~~~~~~~~

src/pages/login.ts:116:58 - error TS2503: Cannot find namespace 'puppeteer'.
 116                             await ((resendCodeButton) as puppeteer.ElementHandle<Element>).click();
                                                              ~~~~~~~~~

src/pages/login.ts:128:45 - error TS2503: Cannot find namespace 'puppeteer'.
 128                     await ((first_input) as puppeteer.ElementHandle<Element>).click();
                                                 ~~~~~~~~~

src/pages/login.ts:155:45 - error TS2503: Cannot find namespace 'puppeteer'.
 155                     await ((first_input) as puppeteer.ElementHandle<Element>).click();
                                                 ~~~~~~~~~

src/pages/login.ts:164:40 - error TS2503: Cannot find namespace 'puppeteer'.
 164                     await ((button) as puppeteer.ElementHandle<Element>).click();
                                            ~~~~~~~~~

src/twitch_drops_bot.ts:8:8 - error TS6133: 'puppeteer' is declared but its value is never read.
   8 import puppeteer, {Browser, TimeoutError, ElementHandle, Page} from "puppeteer";
            ~~~~~~~~~

src/twitch_drops_bot.ts:1322:95 - error TS2503: Cannot find namespace 'puppeteer'.
1322             const element = (await this.#page.waitForXPath("//div[@data-a-player-state]")) as puppeteer.ElementHandle<Element>;
```

I just imported "ElementHandle" from puppeteer and changed `puppeteer.ElementHandle<Element>` to `ElementHandle<Element>` and removed `puppeteer` from `import puppeteer, {TimeoutError} from "puppeteer";` to get rid of TS6133 error.